### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,15 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
         arch:
           - x64
+        include:
+          - os: macos-latest
+            version: '1.10'
+            arch: aarch64
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
